### PR TITLE
Initial version of the SQL adapter

### DIFF
--- a/SQL_Adapter/AdapterActions/Execute.cs
+++ b/SQL_Adapter/AdapterActions/Execute.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using BH.oM.Adapter;
+using BH.oM.Reflection;
+
+namespace BH.Adapter.SQL
+{
+    public partial class SqlAdapter
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public override Output<List<object>, bool> Execute(IExecuteCommand command, ActionConfig actionConfig = null)
+        {
+            Output<List<object>, bool> result = new Output<List<object>, bool> { Item1 = null, Item2 = false };
+
+            Engine.Reflection.Compute.RecordError("Execute is not implemented yet for teh SQl adapter.");
+            return result;
+        }
+
+
+        /***************************************************/
+        /****  Execute Methods                          ****/
+        /***************************************************/
+
+
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_Adapter/AdapterActions/Pull.cs
+++ b/SQL_Adapter/AdapterActions/Pull.cs
@@ -1,0 +1,105 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Data.Requests;
+using BH.oM.Adapter;
+using System.Data.SqlClient;
+using BH.oM.Adapters.SQL;
+using BH.Engine.SQL;
+
+namespace BH.Adapter.SQL
+{
+    public partial class SqlAdapter
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public override IEnumerable<object> Pull(IRequest query, PullType pullType = PullType.AdapterDefault, ActionConfig actionConfig = null)
+        {
+            List<object> result = new List<object>();
+
+            if (query == null)
+                return result;
+
+            using (SqlConnection connection = new SqlConnection(m_ConnectionString))
+            {
+                connection.Open();
+
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = query.IToCommand();
+                    Type objectType = GetDataType(query);
+
+                    SqlDataReader reader = command.ExecuteReader();
+                    while(reader.Read())
+                    {
+                        Dictionary<string, object> dic = new Dictionary<string, object>();
+                        for (int i = 0; i < reader.FieldCount; i++)
+                            dic.Add(reader.GetName(i), reader.GetValue(i));
+                        result.Add(Engine.SQL.Convert.FromDictionary(dic, objectType));
+                    }
+                    reader.Close();
+                }
+
+                connection.Close();
+            }
+
+            return result;
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private Type GetDataType(IRequest request)
+        {
+            if (request == null)
+                return null;
+            
+            if (request is ITypeStrongRequest)
+            {
+                Type type = ((ITypeStrongRequest)request).DataType;
+                if (type != null)
+                    return type;
+            }
+            
+            if (request is ISingleTableRequest)
+            {
+                string table = ((ISingleTableRequest)request).Table;
+                if (m_TableTypes.ContainsKey(table))
+                    return m_TableTypes[table];
+            }
+
+            return null;
+        }
+
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_Adapter/AdapterActions/Push.cs
+++ b/SQL_Adapter/AdapterActions/Push.cs
@@ -1,0 +1,236 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using BH.oM.Adapter;
+using System.Data.SqlClient;
+using BH.oM.Adapters.SQL;
+using BH.Engine.Reflection;
+using BH.Engine.SQL;
+using System.Data;
+
+namespace BH.Adapter.SQL
+{
+    public partial class SqlAdapter
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public override List<object> Push(IEnumerable<object> objects, string tag = "", PushType pushType = PushType.AdapterDefault, ActionConfig actionConfig = null)
+        {
+            List<object> result = new List<object>();
+
+            if (objects == null)
+                return result;
+
+            objects = objects.Where(x => x != null).ToList();
+            if (objects.Count() == 0)
+                return result;
+
+            // Get the type of the pushed objects
+            List<Type> objectTypes = objects.Select(x => x.GetType()).Distinct().ToList();
+            if (objectTypes.Count != 1)
+            {
+                string message = "The SQL adapter only allows to push objects of a single type to a table."
+                    + "\nRight now you are providing objects of the following types: "
+                    + objectTypes.Select(x => x.ToString()).Aggregate((a, b) => a + ", " + b);
+                Engine.Reflection.Compute.RecordError(message);
+                return result;
+            }
+            Type type = objectTypes[0];
+
+            // Get the name of table the objects are pushed to
+            string table = GetTableName(type, actionConfig as PushConfig);
+            if (string.IsNullOrWhiteSpace(table))
+                return result;
+            
+            // Pushing the objects
+            using (SqlConnection connection = new SqlConnection(m_ConnectionString))
+            {
+                connection.Open();
+                InsertObjects(connection, table, objects);
+                connection.Close();
+            }
+
+            return result;
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private string GetTableName(Type objectType, PushConfig config)
+        {
+            // Get possible table from push config
+            string table = null;
+            if (config != null && !string.IsNullOrWhiteSpace(config.Table))
+                table = config.Table;
+
+            // If table is already registered, make sure that the type matches. Return error otherwise
+            if (table != null)
+            {
+                if (m_TableTypes.ContainsKey(table))
+                {
+                    if (objectType == m_TableTypes[table])
+                        return table;
+                    else
+                    {
+                        string message = $"Table {table} expects objects of type {m_TableTypes[table].ToString()}."
+                            + "\nThis doesn't match the type of the objects to push ({objectType.ToString()}).";
+                        Engine.Reflection.Compute.RecordError(message);
+                        return null;
+                    }
+                }
+                else
+                    return table;
+            }
+
+            // Get possible table from 
+            List<string> tables = m_TableTypes.Where(x => x.Value == objectType).Select(x => x.Key).ToList();
+            if (tables.Count == 1)
+                return tables[0];
+            else if (tables.Count == 0)
+            {
+                string message = "The table to push the data to couldn't be infered from the action config or the type of objects pushed.\nPlease provide a PushConfig with a valid table name.";
+                Engine.Reflection.Compute.RecordError(message);
+                return null;
+            }
+            else
+            {
+                string message = "The table name was not provided in the PushConfig. There are multiple tables registed for the type of objects you want to push so the operation was aborded."
+                    + "\nPlease provide a PushConfig with a valid table name. The existing tables for that type are "
+                    + tables.Aggregate((a, b) => a + ", " + b);
+                Engine.Reflection.Compute.RecordError(message);
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        private bool InsertObjects(SqlConnection connection, string table, IEnumerable<object> data)
+        {
+            // Get the schema for the table
+            DataTable dataTable = new DataTable();
+            using (SqlCommand schemaCommand = connection.CreateCommand())
+            {
+                schemaCommand.CommandText = $"SELECT TOP 0 * FROM {table}";
+                SqlDataAdapter da = new SqlDataAdapter(schemaCommand);
+                da.Fill(dataTable);
+                da.Dispose();
+            }
+
+            // Collect the list of properties that need to be added to the table
+            List<string> columns = new List<string>();
+            for (int i = 0; i < dataTable.Columns.Count; i++)
+                columns.Add(dataTable.Columns[i].ColumnName);
+
+            // Add the data to push as rows in the table
+            foreach (object item in data)
+            {
+                Dictionary<string, object> properties = item.PropertyDictionary();
+                DataRow row = dataTable.NewRow();
+
+                foreach (string column in columns)
+                {
+                    if (properties.ContainsKey(column))
+                        row[column] = properties[column];
+                }
+                dataTable.Rows.Add(row);
+            }
+
+            // Push the table in one bulk insert
+            using (SqlBulkCopy bulk = new SqlBulkCopy(connection))
+            {
+                bulk.DestinationTableName = table;
+                bulk.WriteToServer(dataTable);
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private List<string> CreateTable(SqlConnection connection, string table, Type objectType)
+        {
+            if (objectType == null)
+                return new List<string>();
+
+            // Collect the valid properties
+            Dictionary<string, Type> properties = objectType.GetProperties()
+                .Where(x => x.CanRead && x.GetMethod.GetParameters().Count() == 0)
+                .ToDictionary(x => x.Name, x => x.PropertyType);
+
+            return CreateTable(connection, table, properties);
+        }
+
+        /***************************************************/
+
+        private List<string> CreateTable(SqlConnection connection, string table, CustomObject sampleObject)
+        {
+            if (sampleObject == null)
+                return new List<string>();
+
+            Dictionary<string, Type> properties = sampleObject.CustomData
+                .Where(x => x.Value != null)
+                .ToDictionary(x => x.Key, x => x.Value.GetType());
+
+            return CreateTable(connection, table, properties);
+        }
+
+        /***************************************************/
+
+        private List<string> CreateTable(SqlConnection connection, string table, Dictionary<string, Type> properties)
+        {
+            // Collect the valid properties
+            Dictionary<string, Type> columns = new Dictionary<string, Type>();
+            foreach (var prop in properties)
+            {
+                Type propertyType = prop.Value;
+                if (propertyType.IsPrimitive || propertyType.IsEnum || propertyType == typeof(string) || propertyType == typeof(Guid) || propertyType == typeof(DateTime))
+                    columns.Add(prop.Key, propertyType);
+                else
+                    Engine.Reflection.Compute.RecordWarning($"Property {prop.Key} was not added to the table as it is not a primitive type, an enum, a string, a date, or a Guid.");
+            }
+
+            // Create the table in the database
+            using (SqlCommand command = connection.CreateCommand())
+            {
+                command.CommandText = $"CREATE TABLE {table} ("
+                            + columns.Select(x => $"{x.Key} + {x.Value.ToSqlTypeString()}").Aggregate((a, b) => a + ", " + b)
+                            + ")";
+                command.ExecuteNonQuery();
+            }
+
+            return columns.Keys.ToList();
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_Adapter/AdapterActions/Push.cs
+++ b/SQL_Adapter/AdapterActions/Push.cs
@@ -72,7 +72,7 @@ namespace BH.Adapter.SQL
             using (SqlConnection connection = new SqlConnection(m_ConnectionString))
             {
                 connection.Open();
-                InsertObjects(connection, table, objects);
+                result = InsertObjects(connection, table, objects);
                 connection.Close();
             }
 
@@ -132,7 +132,7 @@ namespace BH.Adapter.SQL
 
         /***************************************************/
 
-        private bool InsertObjects(SqlConnection connection, string table, IEnumerable<object> data)
+        private List<object> InsertObjects(SqlConnection connection, string table, IEnumerable<object> data)
         {
             // Get the schema for the table
             DataTable dataTable = new DataTable();
@@ -150,6 +150,7 @@ namespace BH.Adapter.SQL
                 columns.Add(dataTable.Columns[i].ColumnName);
 
             // Add the data to push as rows in the table
+            List<object> addedData = new List<object>();
             foreach (object item in data)
             {
                 Dictionary<string, object> properties = item.PropertyDictionary();
@@ -161,6 +162,7 @@ namespace BH.Adapter.SQL
                         row[column] = properties[column];
                 }
                 dataTable.Rows.Add(row);
+                addedData.Add(item);
             }
 
             // Push the table in one bulk insert
@@ -170,7 +172,7 @@ namespace BH.Adapter.SQL
                 bulk.WriteToServer(dataTable);
             }
 
-            return true;
+            return addedData;
         }
 
         /***************************************************/

--- a/SQL_Adapter/AdapterActions/Remove.cs
+++ b/SQL_Adapter/AdapterActions/Remove.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using BH.oM.Data.Requests;
+using BH.oM.Adapter;
+
+namespace BH.Adapter.SQL
+{
+    public partial class SqlAdapter
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public override int Remove(IRequest filter, ActionConfig actionConfig = null)
+        {
+            Engine.Reflection.Compute.RecordError("Remove is not implemented yet for teh SQl adapter.");
+            return 0;
+        }
+
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_Adapter/Properties/AssemblyInfo.cs
+++ b/SQL_Adapter/Properties/AssemblyInfo.cs
@@ -1,4 +1,26 @@
-﻿using System.Reflection;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/SQL_Adapter/Properties/AssemblyInfo.cs
+++ b/SQL_Adapter/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SQL_Adapter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SQL_Adapter")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4d861e16-ceec-4953-8f6a-1708d8167329")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4D861E16-CEEC-4953-8F6A-1708D8167329}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Adapter.SQL</RootNamespace>
+    <AssemblyName>SQL_Adapter</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Adapter_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM_Adapter">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AdapterActions\Execute.cs" />
+    <Compile Include="AdapterActions\Pull.cs" />
+    <Compile Include="AdapterActions\Push.cs" />
+    <Compile Include="AdapterActions\Remove.cs" />
+    <Compile Include="SqlAdapter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SQL_Engine\SQL_Engine.csproj">
+      <Project>{089e0c4a-e022-4dae-868d-b46f0de06074}</Project>
+      <Name>SQL_Engine</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
+      <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
+      <Name>SQL_oM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -1,89 +1,89 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{4D861E16-CEEC-4953-8F6A-1708D8167329}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.Adapter.SQL</RootNamespace>
-    <AssemblyName>SQL_Adapter</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Adapter_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BHoM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BHoM_Adapter">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Data_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Reflection_Engine">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-    </Reference>
-    <Reference Include="Reflection_oM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AdapterActions\Execute.cs" />
-    <Compile Include="AdapterActions\Pull.cs" />
-    <Compile Include="AdapterActions\Push.cs" />
-    <Compile Include="AdapterActions\Remove.cs" />
-    <Compile Include="SqlAdapter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\SQL_Engine\SQL_Engine.csproj">
-      <Project>{089e0c4a-e022-4dae-868d-b46f0de06074}</Project>
-      <Name>SQL_Engine</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
-      <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
-      <Name>SQL_oM</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-  </PropertyGroup>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<PropertyGroup>
+  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  <ProjectGuid>{4D861E16-CEEC-4953-8F6A-1708D8167329}</ProjectGuid>
+  <OutputType>Library</OutputType>
+  <AppDesignerFolder>Properties</AppDesignerFolder>
+  <RootNamespace>BH.Adapter.SQL</RootNamespace>
+  <AssemblyName>SQL_Adapter</AssemblyName>
+  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  <FileAlignment>512</FileAlignment>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <Optimize>false</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>DEBUG;TRACE</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<ItemGroup>
+  <Reference Include="Adapter_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="BHoM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="BHoM_Adapter">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Data_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="Reflection_Engine">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="Reflection_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  <Reference Include="System" />
+  <Reference Include="System.Core" />
+  <Reference Include="System.Xml.Linq" />
+  <Reference Include="System.Data.DataSetExtensions" />
+  <Reference Include="Microsoft.CSharp" />
+  <Reference Include="System.Data" />
+  <Reference Include="System.Net.Http" />
+  <Reference Include="System.Xml" />
+</ItemGroup>
+<ItemGroup>
+  <Compile Include="AdapterActions\Execute.cs" />
+  <Compile Include="AdapterActions\Pull.cs" />
+  <Compile Include="AdapterActions\Push.cs" />
+  <Compile Include="AdapterActions\Remove.cs" />
+  <Compile Include="SqlAdapter.cs" />
+  <Compile Include="Properties\AssemblyInfo.cs" />
+</ItemGroup>
+<ItemGroup>
+  <ProjectReference Include="..\SQL_Engine\SQL_Engine.csproj">
+    <Project>{089e0c4a-e022-4dae-868d-b46f0de06074}</Project>
+    <Name>SQL_Engine</Name>
+  </ProjectReference>
+  <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
+    <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
+    <Name>SQL_oM</Name>
+  </ProjectReference>
+</ItemGroup>
+<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+<PropertyGroup>
+  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+</PropertyGroup>
 </Project>

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -47,7 +47,7 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Reflection_Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
     </Reference>

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -1,89 +1,90 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-<PropertyGroup>
-  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-  <ProjectGuid>{4D861E16-CEEC-4953-8F6A-1708D8167329}</ProjectGuid>
-  <OutputType>Library</OutputType>
-  <AppDesignerFolder>Properties</AppDesignerFolder>
-  <RootNamespace>BH.Adapter.SQL</RootNamespace>
-  <AssemblyName>SQL_Adapter</AssemblyName>
-  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-  <FileAlignment>512</FileAlignment>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <Optimize>false</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>DEBUG;TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<ItemGroup>
-  <Reference Include="Adapter_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="BHoM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="BHoM_Adapter">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Data_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="Reflection_Engine">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="Reflection_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
-    <Private>False</Private>
-  </Reference>
-  <Reference Include="System" />
-  <Reference Include="System.Core" />
-  <Reference Include="System.Xml.Linq" />
-  <Reference Include="System.Data.DataSetExtensions" />
-  <Reference Include="Microsoft.CSharp" />
-  <Reference Include="System.Data" />
-  <Reference Include="System.Net.Http" />
-  <Reference Include="System.Xml" />
-</ItemGroup>
-<ItemGroup>
-  <Compile Include="AdapterActions\Execute.cs" />
-  <Compile Include="AdapterActions\Pull.cs" />
-  <Compile Include="AdapterActions\Push.cs" />
-  <Compile Include="AdapterActions\Remove.cs" />
-  <Compile Include="SqlAdapter.cs" />
-  <Compile Include="Properties\AssemblyInfo.cs" />
-</ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\SQL_Engine\SQL_Engine.csproj">
-    <Project>{089e0c4a-e022-4dae-868d-b46f0de06074}</Project>
-    <Name>SQL_Engine</Name>
-  </ProjectReference>
-  <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
-    <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
-    <Name>SQL_oM</Name>
-  </ProjectReference>
-</ItemGroup>
-<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
-<PropertyGroup>
-  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-</PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4D861E16-CEEC-4953-8F6A-1708D8167329}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Adapter.SQL</RootNamespace>
+    <AssemblyName>SQL_Adapter</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Adapter_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BHoM_Adapter">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AdapterActions\Execute.cs" />
+    <Compile Include="AdapterActions\Pull.cs" />
+    <Compile Include="AdapterActions\Push.cs" />
+    <Compile Include="AdapterActions\Remove.cs" />
+    <Compile Include="SqlAdapter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SQL_Engine\SQL_Engine.csproj">
+      <Project>{089e0c4a-e022-4dae-868d-b46f0de06074}</Project>
+      <Name>SQL_Engine</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
+      <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
+      <Name>SQL_oM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/SQL_Adapter/SqlAdapter.cs
+++ b/SQL_Adapter/SqlAdapter.cs
@@ -1,0 +1,150 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Adapter.SQL
+{
+    public partial class SqlAdapter : BHoMAdapter
+    {
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public SqlAdapter(string server, string database)
+        {
+            m_ConnectionString = $"Server = {server}; Database = {database}; Trusted_Connection = True;";
+            Initialise();
+        }
+
+        /***************************************************/
+
+        public SqlAdapter(string connectionString)
+        {
+            m_ConnectionString = connectionString;
+            Initialise();
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private void Initialise()
+        {
+            using (SqlConnection connection = new SqlConnection(m_ConnectionString))
+            {
+                connection.Open();
+
+                // Grab the defined types from the _tableTypes table if it exists in the database
+                GrabTableTypes(connection);
+
+                connection.Close();
+            }
+        }
+
+        /***************************************************/
+
+        private void GrabTableTypes(SqlConnection connection)
+        {
+            // Make sure the _tableTypes table exists
+            if (!CheckTableExists(connection, "_tableTypes"))
+                return;
+
+            // Make sure the _tableTypes table contains the required columns
+            List<string> columns = GetTableColumns(connection, "_tableTypes");
+            if (!columns.Contains("TableName") || !columns.Contains("TypeName"))
+                return;
+
+            // Grab the list of table that have an explicit type associated to them
+            using (SqlCommand command = connection.CreateCommand())
+            {
+                command.CommandText = $"SELECT * FROM _tableTypes";
+                SqlDataReader reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    string tableName = reader["TableName"] as string;
+                    string typeName = reader["TypeName"] as string;
+                    if (string.IsNullOrWhiteSpace(tableName) || string.IsNullOrWhiteSpace(typeName))
+                        continue;
+
+                    Type type = Engine.Reflection.Create.Type(typeName, true);
+                    if (type != null)
+                        m_TableTypes[tableName] = type;
+                }
+                reader.Close();
+            }
+        }
+
+        /***************************************************/
+
+        private bool CheckTableExists(SqlConnection connection, string table)
+        {
+            using (SqlCommand command = connection.CreateCommand())
+            {
+                command.CommandText = $"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '_tableTypes'";
+                int nbMatch = (int)command.ExecuteScalar();
+                return nbMatch == 1;
+            }
+        }
+
+        /***************************************************/
+
+        private List<string> GetTableColumns(SqlConnection connection, string table)
+        {
+            // Get the columns names if the table exists
+            List<string> columns = new List<string>();
+            using (SqlCommand command = connection.CreateCommand())
+            {
+                command.CommandText = $"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table}'";
+                SqlDataReader reader = command.ExecuteReader();
+
+                while (reader.Read())
+                    columns.Add(reader["COLUMN_NAME"].ToString());
+                reader.Close();
+            }
+
+            return columns;
+        }
+
+
+        /***************************************************/
+        /**** Private Fields                            ****/
+        /***************************************************/
+
+        private string m_ConnectionString = "";
+
+        private Dictionary<string, Type> m_TableTypes = new Dictionary<string, Type>();
+
+        /***************************************************/
+    }
+}

--- a/SQL_Engine/Convert/FromDictionary.cs
+++ b/SQL_Engine/Convert/FromDictionary.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SQL_Engine/Convert/FromDictionary.cs
+++ b/SQL_Engine/Convert/FromDictionary.cs
@@ -1,0 +1,40 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.SQL
+{
+    public static partial class Convert 
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static object FromDictionary(Dictionary<string, object> dic, Type type = null)
+        {
+            if (type == null && dic.ContainsKey("_t"))
+                type = BH.Engine.Reflection.Create.Type(dic["_t"] as string);
+
+            if (type == null)
+                type = typeof(CustomObject);
+
+            object instance = Activator.CreateInstance(type);
+            foreach (var kvp in dic)
+            {
+                PropertyInfo prop = type.GetProperty(kvp.Key);
+                if (prop != null)
+                    prop.SetValue(instance, kvp.Value);
+                else if (instance is BHoMObject)
+                    ((BHoMObject)instance).CustomData[kvp.Key] = kvp.Value;
+            }
+
+            return instance;
+        }
+
+        /***************************************************/
+    }
+}

--- a/SQL_Engine/Convert/FromDictionary.cs
+++ b/SQL_Engine/Convert/FromDictionary.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.SQL
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static object FromDictionary(Dictionary<string, object> dic, Type type = null)
+        public static object FromDictionary(this Dictionary<string, object> dic, Type type = null)
         {
             if (type == null && dic.ContainsKey("_t"))
                 type = BH.Engine.Reflection.Create.Type(dic["_t"] as string);

--- a/SQL_Engine/Convert/ToCommand.cs
+++ b/SQL_Engine/Convert/ToCommand.cs
@@ -1,0 +1,53 @@
+﻿using BH.oM.Adapters.SQL;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.SQL
+{
+    public static partial class Convert 
+    {
+        /***************************************************/
+        /**** Interface Methods                         ****/
+        /***************************************************/
+
+        public static string IToCommand(this IRequest request)
+        {
+            return ToCommand(request as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static string ToCommand(this TableRequest request)
+        {
+            return $"SELECT {request.Filter} FROM {request.Table}";
+        }
+
+        /***************************************************/
+
+        public static string ToCommand(this oM.Adapters.SQL.CustomRequest request)
+        {
+            return request.Query;
+        }
+
+
+        /***************************************************/
+        /**** Fallback Methods                          ****/
+        /***************************************************/
+
+        private static string ToCommand(this object request)
+        {
+            return "";
+        }
+
+        /***************************************************/
+    }
+}

--- a/SQL_Engine/Convert/ToCommand.cs
+++ b/SQL_Engine/Convert/ToCommand.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Adapters.SQL;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapters.SQL;
 using BH.oM.Base;
 using BH.oM.Data.Requests;
 using System;

--- a/SQL_Engine/Convert/ToSqlTypeString.cs
+++ b/SQL_Engine/Convert/ToSqlTypeString.cs
@@ -1,0 +1,56 @@
+﻿using BH.oM.Adapters.SQL;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.SQL
+{
+    public static partial class Convert 
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static string ToSqlTypeString(this Type type)
+        {
+            // TODO: This is just prototype code for when we enable creation of tables from the adapter
+            switch (type.Name)
+            {
+                case "Boolean":
+                    return "bit(1)";
+                case "Int16":
+                case "UInt16":
+                case "Int32":
+                case "UInt32":
+                case "Int64":
+                case "UInt64":
+                    return "bigint";
+                case "Char":
+                    return "char";
+                case "Single":
+                case "Double":
+                    return "real";
+                case "String":
+                    return "varchar(510)";
+                case "Guid":
+                    return SqlDbType.UniqueIdentifier.ToString();
+                case "DateTime":
+                    return SqlDbType.DateTime.ToString();
+                default:
+                    if (type.IsEnum)
+                        return "varchar(255)";
+                    else
+                        return SqlDbType.Variant.ToString();
+            }
+
+        }
+
+        /***************************************************/
+    }
+}

--- a/SQL_Engine/Convert/ToSqlTypeString.cs
+++ b/SQL_Engine/Convert/ToSqlTypeString.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Adapters.SQL;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapters.SQL;
 using BH.oM.Base;
 using BH.oM.Data.Requests;
 using System;

--- a/SQL_Engine/Properties/AssemblyInfo.cs
+++ b/SQL_Engine/Properties/AssemblyInfo.cs
@@ -1,4 +1,26 @@
-﻿using System.Reflection;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/SQL_Engine/Properties/AssemblyInfo.cs
+++ b/SQL_Engine/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SQL_Engine")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SQL_Engine")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("089e0c4a-e022-4dae-868d-b46f0de06074")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]

--- a/SQL_Engine/SQL_Engine.csproj
+++ b/SQL_Engine/SQL_Engine.csproj
@@ -1,82 +1,83 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{089E0C4A-E022-4DAE-868D-B46F0DE06074}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.Engine.SQL</RootNamespace>
-    <AssemblyName>SQL_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="BHoM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    </Reference>
-    <Reference Include="BHoM_Engine">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Data_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-    </Reference>
-    <Reference Include="Reflection_Engine">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Reflection_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Convert\ToSqlTypeString.cs" />
-    <Compile Include="Convert\ToCommand.cs" />
-    <Compile Include="Convert\FromDictionary.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
-      <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
-      <Name>SQL_oM</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-  </PropertyGroup>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<PropertyGroup>
+  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  <ProjectGuid>{089E0C4A-E022-4DAE-868D-B46F0DE06074}</ProjectGuid>
+  <OutputType>Library</OutputType>
+  <AppDesignerFolder>Properties</AppDesignerFolder>
+  <RootNamespace>BH.Engine.SQL</RootNamespace>
+  <AssemblyName>SQL_Engine</AssemblyName>
+  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  <FileAlignment>512</FileAlignment>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <Optimize>false</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>DEBUG;TRACE</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<ItemGroup>
+  <Reference Include="BHoM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="BHoM_Engine">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="Data_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="Reflection_Engine">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="Reflection_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="System" />
+  <Reference Include="System.Core" />
+  <Reference Include="System.Xml.Linq" />
+  <Reference Include="System.Data.DataSetExtensions" />
+  <Reference Include="Microsoft.CSharp" />
+  <Reference Include="System.Data" />
+  <Reference Include="System.Net.Http" />
+  <Reference Include="System.Xml" />
+</ItemGroup>
+<ItemGroup>
+  <Compile Include="Convert\ToSqlTypeString.cs" />
+  <Compile Include="Convert\ToCommand.cs" />
+  <Compile Include="Convert\FromDictionary.cs" />
+  <Compile Include="Properties\AssemblyInfo.cs" />
+</ItemGroup>
+<ItemGroup>
+  <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
+    <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
+    <Name>SQL_oM</Name>
+  </ProjectReference>
+</ItemGroup>
+<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+<PropertyGroup>
+  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+</PropertyGroup>
 </Project>

--- a/SQL_Engine/SQL_Engine.csproj
+++ b/SQL_Engine/SQL_Engine.csproj
@@ -1,83 +1,84 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-<PropertyGroup>
-  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-  <ProjectGuid>{089E0C4A-E022-4DAE-868D-B46F0DE06074}</ProjectGuid>
-  <OutputType>Library</OutputType>
-  <AppDesignerFolder>Properties</AppDesignerFolder>
-  <RootNamespace>BH.Engine.SQL</RootNamespace>
-  <AssemblyName>SQL_Engine</AssemblyName>
-  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-  <FileAlignment>512</FileAlignment>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <Optimize>false</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>DEBUG;TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<ItemGroup>
-  <Reference Include="BHoM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="BHoM_Engine">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="Data_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="Reflection_Engine">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="Reflection_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="System" />
-  <Reference Include="System.Core" />
-  <Reference Include="System.Xml.Linq" />
-  <Reference Include="System.Data.DataSetExtensions" />
-  <Reference Include="Microsoft.CSharp" />
-  <Reference Include="System.Data" />
-  <Reference Include="System.Net.Http" />
-  <Reference Include="System.Xml" />
-</ItemGroup>
-<ItemGroup>
-  <Compile Include="Convert\ToSqlTypeString.cs" />
-  <Compile Include="Convert\ToCommand.cs" />
-  <Compile Include="Convert\FromDictionary.cs" />
-  <Compile Include="Properties\AssemblyInfo.cs" />
-</ItemGroup>
-<ItemGroup>
-  <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
-    <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
-    <Name>SQL_oM</Name>
-  </ProjectReference>
-</ItemGroup>
-<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
-<PropertyGroup>
-  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-</PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{089E0C4A-E022-4DAE-868D-B46F0DE06074}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Engine.SQL</RootNamespace>
+    <AssemblyName>SQL_Engine</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BHoM_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Convert\ToSqlTypeString.cs" />
+    <Compile Include="Convert\ToCommand.cs" />
+    <Compile Include="Convert\FromDictionary.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
+      <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
+      <Name>SQL_oM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/SQL_Engine/SQL_Engine.csproj
+++ b/SQL_Engine/SQL_Engine.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{089E0C4A-E022-4DAE-868D-B46F0DE06074}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Engine.SQL</RootNamespace>
+    <AssemblyName>SQL_Engine</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    </Reference>
+    <Reference Include="BHoM_Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Data_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="Reflection_Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Convert\ToSqlTypeString.cs" />
+    <Compile Include="Convert\ToCommand.cs" />
+    <Compile Include="Convert\FromDictionary.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SQL_oM\SQL_oM.csproj">
+      <Project>{0a6a3dbf-220b-4c64-8ce5-3e0ddc479404}</Project>
+      <Name>SQL_oM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/SQL_Engine/SQL_Engine.csproj
+++ b/SQL_Engine/SQL_Engine.csproj
@@ -25,31 +25,31 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BHoM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
     </Reference>
-    <Reference Include="BHoM_Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BHoM_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Data_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Data_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
     </Reference>
-    <Reference Include="Reflection_Engine, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Reflection_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>

--- a/SQL_Toolkit.sln
+++ b/SQL_Toolkit.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1382
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQL_Adapter", "SQL_Adapter\SQL_Adapter.csproj", "{4D861E16-CEEC-4953-8F6A-1708D8167329}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQL_oM", "SQL_oM\SQL_oM.csproj", "{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQL_Engine", "SQL_Engine\SQL_Engine.csproj", "{089E0C4A-E022-4DAE-868D-B46F0DE06074}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4D861E16-CEEC-4953-8F6A-1708D8167329}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D861E16-CEEC-4953-8F6A-1708D8167329}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D861E16-CEEC-4953-8F6A-1708D8167329}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D861E16-CEEC-4953-8F6A-1708D8167329}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}.Release|Any CPU.Build.0 = Release|Any CPU
+		{089E0C4A-E022-4DAE-868D-B46F0DE06074}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089E0C4A-E022-4DAE-868D-B46F0DE06074}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089E0C4A-E022-4DAE-868D-B46F0DE06074}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089E0C4A-E022-4DAE-868D-B46F0DE06074}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2469E206-F602-424F-92B0-DFB63A73641D}
+	EndGlobalSection
+EndGlobal

--- a/SQL_oM/Configs/PushConfig.cs
+++ b/SQL_oM/Configs/PushConfig.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Data.Requests;
+using System;
+
+namespace BH.oM.Adapters.SQL
+{
+    public class PushConfig : ActionConfig
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string Table { get; set; } = "";
+
+        public virtual Type DataType { get; set; } = null;
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_oM/Properties/AssemblyInfo.cs
+++ b/SQL_oM/Properties/AssemblyInfo.cs
@@ -1,4 +1,26 @@
-﻿using System.Reflection;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/SQL_oM/Properties/AssemblyInfo.cs
+++ b/SQL_oM/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SQL_oM")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SQL_oM")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0a6a3dbf-220b-4c64-8ce5-3e0ddc479404")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]

--- a/SQL_oM/Requests/CustomRequest.cs
+++ b/SQL_oM/Requests/CustomRequest.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Data.Requests;
+using System;
+
+namespace BH.oM.Adapters.SQL
+{
+    public class CustomRequest : IRequest, ITypeStrongRequest
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string Query { get; set; } = "";
+
+        public virtual Type DataType { get; set; } = null;
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_oM/Requests/ISingleTableRequest.cs
+++ b/SQL_oM/Requests/ISingleTableRequest.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Data.Requests;
+using System;
+
+namespace BH.oM.Adapters.SQL
+{
+    public interface ITypeStrongRequest
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        Type DataType { get; set; }
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_oM/Requests/ITypeStrongRequest.cs
+++ b/SQL_oM/Requests/ITypeStrongRequest.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Data.Requests;
+using System;
+
+namespace BH.oM.Adapters.SQL
+{
+    public interface ISingleTableRequest
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        string Table { get; set; }
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_oM/Requests/TableRequest.cs
+++ b/SQL_oM/Requests/TableRequest.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Data.Requests;
+using System;
+
+namespace BH.oM.Adapters.SQL
+{
+    public class TableRequest : IRequest, ITypeStrongRequest, ISingleTableRequest
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public virtual string Table { get; set; } = "";
+
+        public virtual string Filter { get; set; } = "*";
+
+        public virtual Type DataType { get; set; } = null;
+
+        /***************************************************/
+    }
+}
+
+

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.SQL</RootNamespace>
+    <AssemblyName>SQL_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Adapter_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="BHoM, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="Data_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Configs\PushConfig.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Requests\CustomRequest.cs" />
+    <Compile Include="Requests\ISingleTableRequest.cs" />
+    <Compile Include="Requests\ITypeStrongRequest.cs" />
+    <Compile Include="Requests\TableRequest.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -25,20 +25,20 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Build\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Adapter_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Adapter_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
     </Reference>
-    <Reference Include="BHoM, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null" />
-    <Reference Include="Data_oM, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BHoM" />
+    <Reference Include="Data_oM">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -1,68 +1,69 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.oM.SQL</RootNamespace>
-    <AssemblyName>SQL_oM</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Adapter_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
-    </Reference>
-    <Reference Include="BHoM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    </Reference>
-    <Reference Include="Data_oM">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Configs\PushConfig.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Requests\CustomRequest.cs" />
-    <Compile Include="Requests\ISingleTableRequest.cs" />
-    <Compile Include="Requests\ITypeStrongRequest.cs" />
-    <Compile Include="Requests\TableRequest.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-  </PropertyGroup>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<PropertyGroup>
+  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  <ProjectGuid>{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}</ProjectGuid>
+  <OutputType>Library</OutputType>
+  <AppDesignerFolder>Properties</AppDesignerFolder>
+  <RootNamespace>BH.oM.SQL</RootNamespace>
+  <AssemblyName>SQL_oM</AssemblyName>
+  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  <FileAlignment>512</FileAlignment>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <DebugSymbols>true</DebugSymbols>
+  <DebugType>full</DebugType>
+  <Optimize>false</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>DEBUG;TRACE</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <DebugType>pdbonly</DebugType>
+  <Optimize>true</Optimize>
+  <OutputPath>..\Build\</OutputPath>
+  <DefineConstants>TRACE</DefineConstants>
+  <ErrorReport>prompt</ErrorReport>
+  <WarningLevel>4</WarningLevel>
+</PropertyGroup>
+<ItemGroup>
+  <Reference Include="Adapter_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="BHoM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="Data_oM">
+    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+    <Private>False</Private>
+    <SpecificVersion>False</SpecificVersion>
+  </Reference>
+  <Reference Include="System" />
+  <Reference Include="System.Core" />
+  <Reference Include="System.Xml.Linq" />
+  <Reference Include="System.Data.DataSetExtensions" />
+  <Reference Include="Microsoft.CSharp" />
+  <Reference Include="System.Data" />
+  <Reference Include="System.Net.Http" />
+  <Reference Include="System.Xml" />
+</ItemGroup>
+<ItemGroup>
+  <Compile Include="Configs\PushConfig.cs" />
+  <Compile Include="Properties\AssemblyInfo.cs" />
+  <Compile Include="Requests\CustomRequest.cs" />
+  <Compile Include="Requests\ISingleTableRequest.cs" />
+  <Compile Include="Requests\ITypeStrongRequest.cs" />
+  <Compile Include="Requests\TableRequest.cs" />
+</ItemGroup>
+<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+<PropertyGroup>
+  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+</PropertyGroup>
 </Project>

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -1,69 +1,70 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTarget="" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-<PropertyGroup>
-  <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-  <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-  <ProjectGuid>{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}</ProjectGuid>
-  <OutputType>Library</OutputType>
-  <AppDesignerFolder>Properties</AppDesignerFolder>
-  <RootNamespace>BH.oM.SQL</RootNamespace>
-  <AssemblyName>SQL_oM</AssemblyName>
-  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-  <FileAlignment>512</FileAlignment>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  <DebugSymbols>true</DebugSymbols>
-  <DebugType>full</DebugType>
-  <Optimize>false</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>DEBUG;TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  <DebugType>pdbonly</DebugType>
-  <Optimize>true</Optimize>
-  <OutputPath>..\Build\</OutputPath>
-  <DefineConstants>TRACE</DefineConstants>
-  <ErrorReport>prompt</ErrorReport>
-  <WarningLevel>4</WarningLevel>
-</PropertyGroup>
-<ItemGroup>
-  <Reference Include="Adapter_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="BHoM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="Data_oM">
-    <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
-    <Private>False</Private>
-    <SpecificVersion>False</SpecificVersion>
-  </Reference>
-  <Reference Include="System" />
-  <Reference Include="System.Core" />
-  <Reference Include="System.Xml.Linq" />
-  <Reference Include="System.Data.DataSetExtensions" />
-  <Reference Include="Microsoft.CSharp" />
-  <Reference Include="System.Data" />
-  <Reference Include="System.Net.Http" />
-  <Reference Include="System.Xml" />
-</ItemGroup>
-<ItemGroup>
-  <Compile Include="Configs\PushConfig.cs" />
-  <Compile Include="Properties\AssemblyInfo.cs" />
-  <Compile Include="Requests\CustomRequest.cs" />
-  <Compile Include="Requests\ISingleTableRequest.cs" />
-  <Compile Include="Requests\ITypeStrongRequest.cs" />
-  <Compile Include="Requests\TableRequest.cs" />
-</ItemGroup>
-<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
-<PropertyGroup>
-  <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
-</PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0A6A3DBF-220B-4C64-8CE5-3E0DDC479404}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.SQL</RootNamespace>
+    <AssemblyName>SQL_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Adapter_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Configs\PushConfig.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Requests\CustomRequest.cs" />
+    <Compile Include="Requests\ISingleTableRequest.cs" />
+    <Compile Include="Requests\ITypeStrongRequest.cs" />
+    <Compile Include="Requests\TableRequest.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -35,7 +35,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Adapter_oM.dll</HintPath>
     </Reference>
-    <Reference Include="BHoM" />
+    <Reference Include="BHoM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    </Reference>
     <Reference Include="Data_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,3 @@
+BHoM/BHoM
+BHoM/BHoM_Engine
+BHoM/BHoM_Adapter


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1

See issue for more details

The table that links the tables to types has to be named `_tableTypes` and should contains two properties as follows:

![image](https://user-images.githubusercontent.com/16853390/110759608-c3f97200-8288-11eb-9c4d-4759309e53f5.png)

This is only required if you want your tables to behave in a strong-typed manner but will work without it or if only some of your table are type-strong. 


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SQL_Toolkit/%231-InitialVersion?csf=1&web=1&e=9az7l5
