### PR TITLE
Use TableRequest.Filter for filtering the data instead of columns

### DIFF
--- a/SQL_Adapter/SqlAdapter.cs
+++ b/SQL_Adapter/SqlAdapter.cs
@@ -35,11 +35,6 @@ namespace BH.Adapter.SQL
         /**** Constructors                              ****/
         /***************************************************/
 
-
-        /***************************************************/
-        /**** Public Methods                            ****/
-        /***************************************************/
-
         public SqlAdapter(string server, string database)
         {
             m_ConnectionString = $"Server = {server}; Database = {database}; Trusted_Connection = True;";
@@ -52,6 +47,16 @@ namespace BH.Adapter.SQL
         {
             m_ConnectionString = connectionString;
             Initialise();
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public List<string> GetMatchingTables(Type type)
+        {
+            return m_TableTypes.Where(x => x.Value == type).Select(x => x.Key).ToList();
         }
 
 

--- a/SQL_Engine/Convert/FromDictionary.cs
+++ b/SQL_Engine/Convert/FromDictionary.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Reflection;
 using BH.oM.Base;
 using System;
 using System.Collections.Generic;
@@ -47,13 +48,14 @@ namespace BH.Engine.SQL
             object instance = Activator.CreateInstance(type);
             foreach (var kvp in dic)
             {
-                PropertyInfo prop = type.GetProperty(kvp.Key);
-                if (prop != null)
-                    prop.SetValue(instance, kvp.Value);
-                else if (instance is BHoMObject)
-                    ((BHoMObject)instance).CustomData[kvp.Key] = kvp.Value;
+                try
+                {
+                    if (kvp.Key != "id")
+                        instance.SetPropertyValue(kvp.Key, kvp.Value);
+                }
+                catch { }
             }
-
+                
             return instance;
         }
 

--- a/SQL_Engine/Convert/ToCommand.cs
+++ b/SQL_Engine/Convert/ToCommand.cs
@@ -50,7 +50,15 @@ namespace BH.Engine.SQL
 
         public static string ToCommand(this TableRequest request)
         {
-            return $"SELECT {request.Filter} FROM {request.Table}";
+            string select = "*";
+            if (request.Columns != null && request.Columns.Count > 0)
+                select = request.Columns.Aggregate((a, b) => a + ", " + b);
+
+            string where = "";
+            if (!string.IsNullOrWhiteSpace(request.Filter))
+                where = "WHERE " + request.Filter;
+
+            return $"SELECT {select} FROM {request.Table} {where}";
         }
 
         /***************************************************/

--- a/SQL_oM/Requests/ISingleTableRequest.cs
+++ b/SQL_oM/Requests/ISingleTableRequest.cs
@@ -26,13 +26,13 @@ using System;
 
 namespace BH.oM.Adapters.SQL
 {
-    public interface ITypeStrongRequest
+    public interface ISingleTableRequest
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        Type DataType { get; set; }
+        string Table { get; set; }
 
         /***************************************************/
     }

--- a/SQL_oM/Requests/ITypeStrongRequest.cs
+++ b/SQL_oM/Requests/ITypeStrongRequest.cs
@@ -26,13 +26,13 @@ using System;
 
 namespace BH.oM.Adapters.SQL
 {
-    public interface ISingleTableRequest
+    public interface ITypeStrongRequest
     {
         /***************************************************/
         /**** Properties                                ****/
         /***************************************************/
 
-        string Table { get; set; }
+        Type DataType { get; set; }
 
         /***************************************************/
     }

--- a/SQL_oM/Requests/TableRequest.cs
+++ b/SQL_oM/Requests/TableRequest.cs
@@ -23,6 +23,7 @@
 using BH.oM.Adapter;
 using BH.oM.Data.Requests;
 using System;
+using System.Collections.Generic;
 
 namespace BH.oM.Adapters.SQL
 {
@@ -34,7 +35,9 @@ namespace BH.oM.Adapters.SQL
 
         public virtual string Table { get; set; } = "";
 
-        public virtual string Filter { get; set; } = "*";
+        public virtual List<string> Columns { get; set; } = new List<string>();
+
+        public virtual string Filter { get; set; } = "";
 
         public virtual Type DataType { get; set; } = null;
 

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -59,8 +59,8 @@
     <Compile Include="Configs\PushConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Requests\CustomRequest.cs" />
-    <Compile Include="Requests\ISingleTableRequest.cs" />
     <Compile Include="Requests\ITypeStrongRequest.cs" />
+    <Compile Include="Requests\ISingleTableRequest.cs" />
     <Compile Include="Requests\TableRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #6 
Closes #7 
Closes #8 

Minor fixes found during the development of the BuildingPerformance toolkit


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
- Use TableRequest.Filter for filtering the data instead of columns
- Improve FromDictionary method to better handle type conversion
- Provide a way to get the list of tables matching a specific type

