### PR TITLE
Fix issue with pushing back objects pulled from database

### DIFF
--- a/SQL_Adapter/AdapterActions/Push.cs
+++ b/SQL_Adapter/AdapterActions/Push.cs
@@ -185,10 +185,14 @@ namespace BH.Adapter.SQL
                 DataRow row = dataTable.NewRow();
                 foreach (string column in columns)
                 {
-                    if (properties.ContainsKey(column))
-                        row[column] = properties[column].GetValue(item);
-                    else if (customData.ContainsKey(column))
-                        row[column] = customData[column];
+                    try
+                    {
+                        if (properties.ContainsKey(column))
+                            row[column] = properties[column].GetValue(item);
+                        else if (customData.ContainsKey(column))
+                            row[column] = customData[column];
+                    }
+                    catch { }
                 }
                 dataTable.Rows.Add(row);
                 rows.Add(item);


### PR DESCRIPTION
### Issues addressed by this PR
Fixes issue found in https://github.com/BuroHappoldEngineering/StructureEmbodiedCarbon_Tool/pull/1

Objects pulled from a SQL database come with extra data saved in the CustomData property (e.g. `_id`). That data will fail when pushed back to the database. So we need to make sure it doesn't prevent the other columns to be processed by wrapping it up in a try-catch


### Test files
This is simply adding a try-catch around some code so I am happy with a general code review if this is too difficult to test within the context of the Carbon Calculator tool.
