### PR TITLE
Provides a clear error message on the SQL adapter when used in Rhino 8

### DIFF
--- a/SQL_Adapter/SqlAdapter.cs
+++ b/SQL_Adapter/SqlAdapter.cs
@@ -100,14 +100,21 @@ namespace BH.Adapter.SQL
 
         private void Initialise()
         {
-            using (SqlConnection connection = new SqlConnection(m_ConnectionString))
+            try
             {
-                connection.Open();
+                using (SqlConnection connection = new SqlConnection(m_ConnectionString))
+                {
+                    connection.Open();
 
-                // Grab the defined types from the _tableTypes table if it exists in the database
-                GrabTableTypes(connection);
+                    // Grab the defined types from the _tableTypes table if it exists in the database
+                    GrabTableTypes(connection);
 
-                connection.Close();
+                    connection.Close();
+                }
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                BH.Engine.Base.Compute.RecordError("SQL is not supported in this UI. Please use Grasshopper in Rhino 7 or Excel.");
             }
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #63 

See issue and its parent issue for more details.

We now get this error message on both versions of the adapter:

![image](https://github.com/user-attachments/assets/fbf7dd42-5a49-4650-b62c-599d6bf46b4e)
![image](https://github.com/user-attachments/assets/c7d8e25b-da67-4062-8dab-d1b3e44ba8d4)


### Test files
As it's related to a connection to our internal database, I will share a test file separately.

