### PR TITLE
Consolidate versions of external dependencies

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.SQL.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.SQL.nuspec
@@ -16,7 +16,7 @@
     <title></title>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Data.SqlClient" version="5.1.1" />
+        <dependency id="Microsoft.Data.SqlClient" version="6.1.4" />
         <dependency id="Microsoft.EntityFrameworkCore" version = "3.1.32" />
         <dependency id="NETStandard.Library" version="2.0.3" />
         <dependency id="Microsoft.CSharp" version="4.7.0" />

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -25,7 +25,7 @@
   <ItemGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #78

Microsoft.Data.SqlClient was upgraded to version 6.1.4 as version 5.1.1 was deprecated. 

Why not stay in 5.1.x?

  The entire 5.1 branch (including 5.1.3) reached end-of-life on January 20, 2026 — it was the previous LTS. No further security patches will be issued for it. Staying there is not a safe harbour.

  #### Why 6.1.4 specifically?

  It is the current LTS branch, with official Microsoft support until August 14, 2028 (~2.5 years). This is directly confirmed by the https://learn.microsoft.com/en-us/sql/connect/ado-net/sqlclient-driver-support-lifecycle. The .4
   patch is the most hardened: 6.1.0 had regressions that were fixed in 6.1.1, and four patches have since landed.

 ####  Why not 7.0.0 (latest)?

  7.0 is STS (Short-Term Support) and introduces two meaningful breaking changes:
  - Azure/Entra ID authentication has been extracted to a separate package (Microsoft.Data.SqlClient.Extensions.Azure) — if any auth methods like ActiveDirectory* are used, they'd break silently.
  - The default Encrypt connection behaviour changed from false to true.

 #### The netstandard2.0 nuance (important for your ZeroCodeTool/Blazor config)

  - 6.0 dropped netstandard2.0 entirely — incompatible.
  - 6.1 restored it, but as a reference assembly. For a Blazor end-application (which ZeroCodeTool is), the build system correctly resolves to the proper runtime DLL automatically — this is transparent in practice.


### Test files
There isn't really a good way to test this since this purely targets zero-code tools. The good new is that zero-code tools depends on a nuget package of the BHoM, not on direct dlls. Most of the ZCT are also already using a 6.1.X version of Microsoft.Data.SqlClient so we know that this package works well with our template.

@michaelhoehn , if you're comfortable with, I would just do a code inspection and make sure it builds in all configs. 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->