### PR TITLE
Fix the SQL adaper in Rhino 8

### DIFF
--- a/SQL_Adapter/AdapterActions/Execute.cs
+++ b/SQL_Adapter/AdapterActions/Execute.cs
@@ -33,7 +33,7 @@ using BH.Engine.Base;
 
 using System.Data;
 
-#if ZCTDEPLOY
+#if ZCTDEPLOY || NET7_0_OR_GREATER
 using Microsoft.Data.SqlClient;
 #else
 using System.Data.SqlClient;

--- a/SQL_Adapter/AdapterActions/Pull.cs
+++ b/SQL_Adapter/AdapterActions/Pull.cs
@@ -28,7 +28,7 @@ using BH.oM.Adapter;
 using BH.oM.Adapters.SQL;
 using BH.Engine.SQL;
 
-#if ZCTDEPLOY
+#if ZCTDEPLOY || NET7_0_OR_GREATER
 using Microsoft.Data.SqlClient;
 #else
 using System.Data.SqlClient;

--- a/SQL_Adapter/AdapterActions/Push.cs
+++ b/SQL_Adapter/AdapterActions/Push.cs
@@ -31,7 +31,7 @@ using BH.Engine.SQL;
 using System.Data;
 using System.Reflection;
 
-#if ZCTDEPLOY
+#if ZCTDEPLOY || NET7_0_OR_GREATER
 using Microsoft.Data.SqlClient;
 #else
 using System.Data.SqlClient;

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -44,7 +44,9 @@
     <Exec Condition="'$(TargetFramework)'=='net7.0'"
           Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
     <Exec Condition="'$(TargetFramework)'=='net7.0'"
-          Command="xcopy &quot;$(TargetDir)Microsoft.Data.SqlClient.dll&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
+          Command="xcopy &quot;$(TargetDir)runtimes\win\lib\net6.0\Microsoft.Data.SqlClient.dll&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
+	  <Exec Condition="'$(TargetFramework)'=='net7.0'"
+			Command="xcopy &quot;$(TargetDir)runtimes\win-x64\native\Microsoft.Data.SqlClient.SNI.dll&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
 	<Exec Condition="'$(TargetFramework)'=='net7.0'"
 		Command="if not exist &quot;$(ProgramData)\BHoM\Settings\&quot; mkdir &quot;$(ProgramData)\BHoM\Settings\&quot; /Y" />
     <Exec Condition="'$(TargetFramework)'=='net7.0'"

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -38,6 +38,9 @@
           Command="if not exist &quot;$(ProgramData)\BHoM\Assemblies\netfx\&quot; mkdir &quot;$(ProgramData)\BHoM\Assemblies\netfx&quot;" />
     <Exec Condition="'$(TargetFramework)'=='net472'"
           Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies\netfx\&quot; /Y" />
+	  <!-- backward compatibility: root Assemblies subdirectory -->
+	<Exec Condition="'$(TargetFramework)'=='net472'"
+	      Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
     <!-- net7.0: SQL_Adapter.dll + Microsoft.Data.SqlClient.dll → net7.0 subdirectory -->
     <Exec Condition="'$(TargetFramework)'=='net7.0'"
           Command="if not exist &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; mkdir &quot;$(ProgramData)\BHoM\Assemblies\net7.0&quot;" />

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net7.0</TargetFrameworks>
     <DefineConstants>INSTALLERDEPLOY</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
@@ -28,8 +28,25 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+  </ItemGroup>
+
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
+    <!-- net472: netfx subdirectory -->
+    <Exec Condition="'$(TargetFramework)'=='net472'"
+          Command="if not exist &quot;$(ProgramData)\BHoM\Assemblies\netfx\&quot; mkdir &quot;$(ProgramData)\BHoM\Assemblies\netfx&quot;" />
+    <Exec Condition="'$(TargetFramework)'=='net472'"
+          Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies\netfx\&quot; /Y" />
+    <!-- net7.0: SQL_Adapter.dll + Microsoft.Data.SqlClient.dll → net7.0 subdirectory -->
+    <Exec Condition="'$(TargetFramework)'=='net7.0'"
+          Command="if not exist &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; mkdir &quot;$(ProgramData)\BHoM\Assemblies\net7.0&quot;" />
+    <Exec Condition="'$(TargetFramework)'=='net7.0'"
+          Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
+    <Exec Condition="'$(TargetFramework)'=='net7.0'"
+          Command="xcopy &quot;$(TargetDir)Microsoft.Data.SqlClient.dll&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
+	<Exec Condition="'$(TargetFramework)'=='net7.0'"
+		Command="xcopy &quot;$(TargetDir)$(TargetName).deps.json&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
   </Target>
 
   <ItemGroup>
@@ -65,7 +82,7 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
+  <ItemGroup Condition="('$(Configuration)'=='Debug' Or '$(Configuration)'=='Release') And '$(TargetFramework)'=='net472'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/SQL_Adapter/SQL_Adapter.csproj
+++ b/SQL_Adapter/SQL_Adapter.csproj
@@ -46,7 +46,9 @@
     <Exec Condition="'$(TargetFramework)'=='net7.0'"
           Command="xcopy &quot;$(TargetDir)Microsoft.Data.SqlClient.dll&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
 	<Exec Condition="'$(TargetFramework)'=='net7.0'"
-		Command="xcopy &quot;$(TargetDir)$(TargetName).deps.json&quot; &quot;$(ProgramData)\BHoM\Assemblies\net7.0\&quot; /Y" />
+		Command="if not exist &quot;$(ProgramData)\BHoM\Settings\&quot; mkdir &quot;$(ProgramData)\BHoM\Settings\&quot; /Y" />
+    <Exec Condition="'$(TargetFramework)'=='net7.0'"
+		  Command="xcopy &quot;$(ProjectDir)Settings\SqlClientAssemblyFix.json&quot; &quot;$(ProgramData)\BHoM\Settings\&quot; /Y" />
   </Target>
 
   <ItemGroup>

--- a/SQL_Adapter/Settings/SqlClientAssemblyFix.json
+++ b/SQL_Adapter/Settings/SqlClientAssemblyFix.json
@@ -1,5 +1,5 @@
 {
-  "_t": "BH.oM.Adapters.SQL.SqlClientAssemblyFixSetting",
+  "_t": "BH.oM.Adapters.SQL.SqlClientAssemblyFixSettings",
   "BHoM_Guid": "a3f2c1d0-b4e5-4f60-8a9b-c1d2e3f40001",
   "Name": "",
   "Tags": [],

--- a/SQL_Adapter/Settings/SqlClientAssemblyFix.json
+++ b/SQL_Adapter/Settings/SqlClientAssemblyFix.json
@@ -1,0 +1,10 @@
+{
+  "_t": "BH.oM.Adapters.SQL.SqlClientAssemblyFixSetting",
+  "BHoM_Guid": "a3f2c1d0-b4e5-4f60-8a9b-c1d2e3f40001",
+  "Name": "",
+  "Tags": [],
+  "Fragments": [],
+  "CustomData": {},
+  "InitialisationMethod": "BH.Engine.SQL.Compute.PreloadSqlClient",
+  "InitialisationAssembly": "SQL_Engine"
+}

--- a/SQL_Adapter/SqlAdapter.cs
+++ b/SQL_Adapter/SqlAdapter.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.Engine.Base;
 
-#if ZCTDEPLOY
+#if ZCTDEPLOY || NET7_0_OR_GREATER
 using Microsoft.Data.SqlClient;
 #else
 using System.Data.SqlClient;
@@ -38,12 +38,28 @@ namespace BH.Adapter.SQL
     public partial class SqlAdapter : BHoMAdapter
     {
         /***************************************************/
+        /**** Static Constructor                        ****/
+        /***************************************************/
+
+#if NET7_0_OR_GREATER
+        static SqlAdapter()
+        {
+            // Use managed TCP sockets instead of the native SNI DLL.
+            // Required on CoreCLR hosts (Rhino 8) where the native SNI library is not on
+            // the DLL search path. Effective only on actual .NET 7+ processes — ignored
+            // when a net472 build runs under CoreCLR compat mode, which is why this
+            // switch must live in the net7.0-targeted build, not the net472 build.
+            AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
+        }
+#endif
+
+        /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
 
         public SqlAdapter(string server, string database)
         {
-#if ZCTDEPLOY
+#if ZCTDEPLOY || NET7_0_OR_GREATER
             m_ConnectionString = $"Server = {server}; Database = {database}; Trusted_Connection = True; TrustServerCertificate=True";
 #else
             m_ConnectionString = $"Server = {server}; Database = {database}; Trusted_Connection = True;";
@@ -112,9 +128,9 @@ namespace BH.Adapter.SQL
                     connection.Close();
                 }
             }
-            catch (PlatformNotSupportedException ex)
+            catch (Exception ex)
             {
-                BH.Engine.Base.Compute.RecordError("SQL is not supported in this UI. Please use Grasshopper in Rhino 7 or Excel.");
+                BH.Engine.Base.Compute.RecordError($"Failed to connect to SQL Server: {ex.Message}");
             }
         }
 

--- a/SQL_Engine/Compute/PreloadSqlClient.cs
+++ b/SQL_Engine/Compute/PreloadSqlClient.cs
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Base;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.SQL
+{
+    public static partial class Compute 
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Make sure the correct version of Microsoft.Data.SqlClient before Rhino 8 has a chance to load its stub dll. Temporary solution while wating for a fix from McNeel.")]
+        [Output("success", "return true if the code was executed without error.")]
+        public static bool PreloadSqlClient()
+        {
+            // Only relevant on .NET 5+ (CoreCLR / Rhino 8).
+            // On .NET Framework 4.7.2 (Rhino 7) the System.Data.SqlClient inbox provider is used
+            // and Microsoft.Data.SqlClient is not involved.
+            if (Environment.Version.Major < 5)
+                return true;
+
+            // Assembly path for the version of the SqlCleint we want to load
+            string assemblyPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "BHoM", "Assemblies", "net7.0", "Microsoft.Data.SqlClient.dll");
+
+            // Guard: if SqlClient is already in the Default ALC we are too late.
+            // Check whether what is loaded is the real implementation or Rhino's stub.
+            Assembly already = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "Microsoft.Data.SqlClient");
+
+            if (already != null)
+            {
+                if (!already.Location.Contains("BHoM"))
+                {
+                    BH.Engine.Base.Compute.RecordWarning(
+                        "Microsoft.Data.SqlClient was already loaded from Rhino's directory before the SQL Toolkit " +
+                        $"pre-load could run: {already.Location}. The SQL Adapter will not work correctly in Rhino 8. " +
+                        "This indicates that a Rhino plugin loaded the stub at Rhino startup. " +
+                        "Consider switching to the ALC-isolation approach described in 14_OptionA_ALC_Implementation.md.");
+                    return false;
+                }
+
+                // Already loaded from BHoM's own directory — nothing to do.
+                return true;
+            }
+
+            if (!File.Exists(assemblyPath))
+            {
+                BH.Engine.Base.Compute.RecordWarning(
+                    $"Microsoft.Data.SqlClient.dll was not found at the expected path: {assemblyPath}. " +
+                    "The SQL Adapter may not work correctly in Rhino 8. " +
+                    "Ensure SQL_Adapter has been built with the net7.0 target framework.");
+                return false;
+            }
+
+            try
+            {
+                Assembly.LoadFrom(assemblyPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                BH.Engine.Base.Compute.RecordError(ex, "Failed to pre-load Microsoft.Data.SqlClient from the BHoM Assemblies folder.");
+                return false;
+            }
+        }
+
+        /***************************************************/
+    }
+}
+
+
+
+
+

--- a/SQL_Engine/SQL_Engine.csproj
+++ b/SQL_Engine/SQL_Engine.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DefineConstants>INSTALLERDEPLOY</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
@@ -22,7 +22,7 @@
     <DefineConstants>ZCTDEPLOY</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
@@ -57,15 +57,5 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
 
 </Project>

--- a/SQL_oM/SQL_oM.csproj
+++ b/SQL_oM/SQL_oM.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DefineConstants>INSTALLERDEPLOY</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
@@ -44,15 +44,5 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
 
 </Project>

--- a/SQL_oM/ToolkitSettings/SqlClientAssemblyFixSettings.cs
+++ b/SQL_oM/ToolkitSettings/SqlClientAssemblyFixSettings.cs
@@ -30,7 +30,7 @@ namespace BH.oM.Adapters.SQL
 {
     [Description("Initialisation settings for the SQL Toolkit ensuring that the correct Microsoft.Data.SqlClient assembly " +
                  "is loaded before any SQL component is used in Rhino 8. This is a fix until McNeel ships a working version of that dll.")]
-    public class SqlClientAssemblyFixSetting : BHoMObject, ISettings, IInitialisationSettings
+    public class SqlClientAssemblyFixSettings : BHoMObject, ISettings, IInitialisationSettings
     {
         /***************************************************/
         /**** Properties                                ****/

--- a/SQL_oM/ToolkitSettings/SqlClientAssemblyFixSettings.cs
+++ b/SQL_oM/ToolkitSettings/SqlClientAssemblyFixSettings.cs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using System;
+using System.ComponentModel;
+
+namespace BH.oM.Adapters.SQL
+{
+    [Description("Initialisation settings for the SQL Toolkit ensuring that the correct Microsoft.Data.SqlClient assembly " +
+                 "is loaded before any SQL component is used in Rhino 8. This is a fix until McNeel ships a working version of that dll.")]
+    public class SqlClientAssemblyFixSetting : BHoMObject, ISettings, IInitialisationSettings
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        [Description("Method ran when the UI is loaded. This is in charge of loading the Microsoft.Data.SqlClient if we are in Rhino 8.")]
+        public virtual string InitialisationMethod { get; } = "BH.Engine.SQL.Compute.PreloadSqlClient";
+
+        [Description("Assmbly where the initialisation method can be found.")]
+        public virtual string InitialisationAssembly { get; } = "SQL_Engine";
+
+        /***************************************************/
+    }
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
While it doesn't depend on those PR to compile, the solution provided here will only be fully working once those other two PRs are also merged/compiled:
 - https://github.com/BHoM/BHoM_UI/pull/550: This is necessary for the assemblies in the sub-folder to be picked up by teh BHoM UI.
 - https://github.com/BHoM/BHoM_Installer/pull/259: This makes sure that the settings file that front-load Microsoft.Data.SqlClient in .net core frameworks is also distributed with the installer.
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #62 

Now compile the SQL adapter for two different frameworks and copies the dlls in their respective sub-folders in `BHoM\Assemblies`


### Test files
One file for each version of Rhino:
[SQLCompatibilityTest.zip](https://github.com/user-attachments/files/28021917/SQLCompatibilityTest.zip)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->